### PR TITLE
Fix future dates and some message-list css bugs

### DIFF
--- a/client/src/components/message-list.vue
+++ b/client/src/components/message-list.vue
@@ -1,6 +1,6 @@
 <template>
 	<!-- TODO: this is awful :D split this to smaller components or something -->
-	
+
 	<ul class='message-list'>
 		<div class="date-message-block" v-for="dayGroup in messagesGroupedByDay">
 
@@ -78,6 +78,8 @@ export default {
 .message-list {
 	padding-left: 2px;
 	margin: 0px;
+
+	overflow-x: hidden;
 }
 
 .user-message-block {

--- a/client/src/misc/relative-date.js
+++ b/client/src/misc/relative-date.js
@@ -49,10 +49,6 @@ const toOrdinalNumber = (day) => { // 1 -> "1st" etc
 
 // returns for example "Yesterday", "Last Tuesday", "March 20th", "July 2nd, 2015"
 const categorizeRelatively = (time, now) => {
-	if(time > now) {
-		// TODO: display a more descriptive date :P ?
-		return "In the future!";
-	}
 
 	const diffInDays = differenceInDays(time, now);
 	if(diffInDays < DAYS_IN_WEEK * 2) { // less than two weeks
@@ -72,6 +68,13 @@ const categorizeRelatively = (time, now) => {
 		else if(diffInDays <= weekDayNow + 7) {
 			// last week
 			return `Last ${Weekdays[weekday(time)]}`;
+		}
+		// aka, IS IN THE FUTURE
+		else if(diffInDays < 0) {
+			if(diffInDays === -1) return "Tomorrow";
+
+			// TODO: display a more descriptive date :P ?
+			return "In the future!";
 		}
 	}
 


### PR DESCRIPTION
Partially fixes #20. Horizontal scrollbar is now never seen, but too long messages are still not wrapped to multiple lines