### PR TITLE
Refactor message-list to not to use any css hacks

### DIFF
--- a/client/src/components/message-input.vue
+++ b/client/src/components/message-input.vue
@@ -1,5 +1,10 @@
 <template>
-	<textarea class="input-field" ref="input" @keydown.enter="onEnterPressed" placeholder="enter message" autofocus></textarea>
+	<textarea
+		ref="input"
+		class="input-field"
+		@keydown.enter="onEnterPressed"
+		placeholder="enter message" autofocus>
+	</textarea>
 </template>
 
 <script>
@@ -9,32 +14,26 @@ export default {
 	name: 'message-input',
 
 	mounted() {
-	//	this.forceAlwaysFocused(this.$refs.input);
+		// when room changes, refocus message-input
+		this.$store.watch(
+			state => state.currentRoom,
+			() => this.$refs.input.focus()
+		);
 	},
-	
+
 	methods: {
 		onEnterPressed(event) {
 			event.preventDefault(); // makes the element ignore default enter press behavior
 
 			const inputField = event.target;
 			const text = inputField.value;
-			
+
 			if(text.trim().length > 0) { // if not empty message
 				this.$store.dispatch('sendMessage', text);
 			}
-			
+
 			// clear the input field
 			inputField.value = "";
-		},
-
-		forceAlwaysFocused(textarea) {
-			textarea.focus();
-			textarea.onblur = () => setTimeout(() => textarea.focus()); // onblur == "on unfocus"
-			textarea.onkeydown = e => { 
-				// prevents default tab behavior (tab == 9)
-				const key = e.which || e.keyCode;
-				if(key == 9) e.preventDefault() 
-			};
 		},
 	}
 }
@@ -51,7 +50,7 @@ export default {
 
 	resize: none;
     outline: none;
-	
+
 	font-size: 20px;
 	font-weight: 500;
 }

--- a/deploy/deploy-client-ghpages.sh
+++ b/deploy/deploy-client-ghpages.sh
@@ -9,6 +9,6 @@ $(cd client && yarn run build)
 # and then build the build.js there and copy index.html.
 # right now, this script fails if gh-pages isn't cloned into /dist
 echo 'Note: you must clone the gh-pages branch to /client/dist with
-"git clone -b mybranch --single-branch <<REPO_URL>>"'
+"git clone -b gh-pages --single-branch <<REPO_URL>>"'
 
 $(cd client/dist && git add . && git commit -m "New build" && git push origin gh-pages)


### PR DESCRIPTION
In other words, don't reverse the list and transform: scaleY(-1). Fixes few other problems, like reverse scrolling, firefox text flickering, text selection not working properly etc.

Also made a fix so that message-input is always refocused when the room changes.

Fixes #32, #37, #27.